### PR TITLE
Make it slow by adding candidates for deferred references

### DIFF
--- a/WpfDeferredResourceLookupRepro/Styles/Styles.xaml
+++ b/WpfDeferredResourceLookupRepro/Styles/Styles.xaml
@@ -5,9 +5,6 @@
 
     <sys:String x:Key="__Identity">Styles.xaml</sys:String>
 
-    <SolidColorBrush Color="Red" x:Key="RedBrush" />
-    <SolidColorBrush Color="Blue" x:Key="BlueBrush" />
-
     <SolidColorBrush x:Key="Pink" Color="DeepPink" />
     <SolidColorBrush x:Key="Foreground" Color="AliceBlue" />
     <SolidColorBrush x:Key="BorderBrush" Color="SaddleBrown" />

--- a/WpfDeferredResourceLookupRepro/Styles/Styles.xaml
+++ b/WpfDeferredResourceLookupRepro/Styles/Styles.xaml
@@ -2,8 +2,15 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:WpfDeferredResourceLookupRepro.Controls" 
                     xmlns:sys="clr-namespace:System;assembly=System.Runtime">
-    
+
     <sys:String x:Key="__Identity">Styles.xaml</sys:String>
+
+    <SolidColorBrush Color="Red" x:Key="RedBrush" />
+    <SolidColorBrush Color="Blue" x:Key="BlueBrush" />
+
+    <SolidColorBrush x:Key="Pink" Color="DeepPink" />
+    <SolidColorBrush x:Key="Foreground" Color="AliceBlue" />
+    <SolidColorBrush x:Key="BorderBrush" Color="SaddleBrown" />
 
     <Style TargetType="TextBox">
         <Setter Property="VerticalAlignment" Value="Center" />


### PR DESCRIPTION
I think the slowness was not visible because WPF would not treat the _DynamicResource_ references the same way when there's just one candidate for the key among all the dictionaries.